### PR TITLE
[RFR] Allow overriding queries by using fragments

### DIFF
--- a/graphql.config.json
+++ b/graphql.config.json
@@ -1,0 +1,37 @@
+{
+
+  "README_schema" : "Specifies how to load the GraphQL schema that completion, error highlighting, and documentation is based on in the IDE",
+  "schema": {
+
+    "README_file" : "Remove 'file' to use request url below. A relative or absolute path to the JSON from a schema introspection query, e.g. '{ data: ... }' or a .graphql/.graphqls file describing the schema using GraphQL Schema Language. Changes to the file are watched.",
+
+    "README_request" : "To request the schema from a url instead, remove the 'file' JSON property above (and optionally delete the default graphql.schema.json file).",
+    "request": {
+      "url" : "https://eu1.prisma.sh/flavian/ra-data-prisma/dev",
+      "method" : "POST",
+      "README_postIntrospectionQuery" : "Whether to POST an introspectionQuery to the url. If the url always returns the schema JSON, set to false and consider using GET",
+      "postIntrospectionQuery" : true,
+      "README_options" : "See the 'Options' section at https://github.com/then/then-request",
+      "options" : {
+        "headers": {
+          "user-agent" : "JS GraphQL"
+        }
+      }
+    }
+
+  },
+
+  "README_endpoints": "A list of GraphQL endpoints that can be queried from '.graphql' files in the IDE",
+  "endpoints" : [
+    {
+      "name": "Default (http://localhost:8080/graphql)",
+      "url": "https://eu1.prisma.sh/flavian/ra-data-prisma/dev",
+      "options" : {
+        "headers": {
+          "user-agent" : "JS GraphQL"
+        }
+      }
+    }
+  ]
+
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,30 +1,14 @@
 import React, { Component } from 'react';
 import './App.css';
 
-import {
-  Admin,
-  Resource,
-  Delete,
-  List,
-  Datagrid,
-  TextField,
-  ReferenceField,
-  ReferenceManyField,
-  EditButton,
-  ShowButton,
-  Edit,
-  DisabledInput,
-  TextInput,
-  SimpleForm,
-  SingleFieldList,
-  ChipField
-} from 'react-admin';
+import { Admin, Resource, GET_LIST } from 'react-admin';
+import gql from 'graphql-tag';
+
 import buildPrismaProvider from './adaptator';
 
 import { ProductEdit, ProductList } from './components/products';
 import { ShopEdit, ShopList } from './components/shops';
 import { OrderList } from './components/orders';
-import { VariantList } from './components/variants';
 import { CategoryCreate, CategoryEdit, CategoryList, CategoryShow } from './components/categories';
 import { BrandCreate, BrandEdit, BrandList, BrandShow } from './components/brands';
 import {
@@ -44,7 +28,97 @@ class App extends Component {
 
   componentDidMount() {
     buildPrismaProvider({
-      clientOptions: { uri: 'https://eu1.prisma.sh/flavian/ra-data-prisma/dev' }
+      clientOptions: { uri: 'https://eu1.prisma.sh/flavian/ra-data-prisma/dev' },
+      overrideQueriesByFragment: {
+        Product: {
+          [GET_LIST]: gql`
+            fragment product on Product {
+              id
+              name
+              description
+              brand {
+                id
+                name
+              }
+              category {
+                id
+                name
+              }
+              shop {
+                id
+                name
+              }
+              attributes {
+                id
+                value
+              }
+            }
+          `
+        },
+        Order: {
+          [GET_LIST]: gql`
+            fragment order on Order {
+              id
+              totalPrice
+              owner {
+                id
+                firstName
+              }
+              lineItems {
+                id
+                quantity
+                variant {
+                  id
+                  available
+                  price
+                  product {
+                    id
+                    name
+                  }
+                  selectedOptions {
+                    id
+                    value {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          `
+        },
+        Brand: {
+          [GET_LIST]: `{
+            id
+            name
+            category { id name }
+            shop { id name }
+          }`
+        },
+        Category: {
+          [GET_LIST]: `{
+            id
+            name
+            shop { id name }
+          }`
+        },
+        Attribute: {
+          [GET_LIST]: `{
+            id
+            value
+            category { id name }
+            shop { id name }
+          }`
+        },
+        Option: {
+          [GET_LIST]: ` {
+            id
+            name
+            values { id name }
+            shop { id name }
+          }`
+        }
+      }
     }).then(dataProvider => this.setState({ dataProvider }));
   }
 

--- a/src/adaptator/buildGqlQuery.js
+++ b/src/adaptator/buildGqlQuery.js
@@ -101,12 +101,18 @@ const convertSelectionSetToGraphqlifyFields = selectionSet => {
   }, {});
 };
 
-const buildFieldsFromFragment = fragment => {
+//TODO: validate fragment against the schema
+const buildFieldsFromFragment = (fragment, typeName) => {
   let parsedFragment = {};
 
-  if (typeof fragment === 'object' && fragment.kind === 'Document') {
+  if (typeof fragment === 'object' && fragment.kind && fragment.kind === 'Document') {
     parsedFragment = fragment;
   } else if (typeof fragment === 'string') {
+
+    if (!fragment.startsWith('fragment')) {
+      fragment = `fragment tmp on ${typeName} ${fragment}`;
+    }
+
     parsedFragment = parse(fragment);
   }
 
@@ -124,7 +130,8 @@ export default introspectionResults => (
   const args = buildArgs(queryType, variables);
   const fields = isQueryOverriden(overrideQueriesByFragment, resource.type.name, aorFetchType)
     ? buildFieldsFromFragment(
-        getOverridenQuery(overrideQueriesByFragment, resource.type.name, aorFetchType)
+        getOverridenQuery(overrideQueriesByFragment, resource.type.name, aorFetchType),
+        resource.type.name
       )
     : buildFields(introspectionResults)(resource.type.fields);
 

--- a/src/adaptator/buildQuery.js
+++ b/src/adaptator/buildQuery.js
@@ -7,10 +7,10 @@ export const buildQueryFactory = (
   buildVariablesImpl,
   buildGqlQueryImpl,
   getResponseParserImpl
-) => (introspectionResults, otherOptions) => {
+) => (introspectionResults) => {
   const knownResources = introspectionResults.resources.map(r => r.type.name);
 
-  return (aorFetchType, resourceName, params) => {
+  return (aorFetchType, resourceName, params, fragment) => {
     const resource = introspectionResults.resources.find(r => r.type.name === resourceName);
 
     if (!resource) {
@@ -31,20 +31,18 @@ export const buildQueryFactory = (
       );
     }
 
-    const { overrideQueriesByFragment } = otherOptions;
-
     const variables = buildVariablesImpl(introspectionResults)(
       resource,
       aorFetchType,
       params,
-      queryType,
+      queryType
     );
     const query = buildGqlQueryImpl(introspectionResults)(
       resource,
       aorFetchType,
       queryType,
       variables,
-      overrideQueriesByFragment
+      fragment
     );
     const parseResponse = getResponseParserImpl(introspectionResults)(
       aorFetchType,

--- a/src/adaptator/buildQuery.js
+++ b/src/adaptator/buildQuery.js
@@ -7,7 +7,7 @@ export const buildQueryFactory = (
   buildVariablesImpl,
   buildGqlQueryImpl,
   getResponseParserImpl
-) => introspectionResults => {
+) => (introspectionResults, otherOptions) => {
   const knownResources = introspectionResults.resources.map(r => r.type.name);
 
   return (aorFetchType, resourceName, params) => {
@@ -31,17 +31,20 @@ export const buildQueryFactory = (
       );
     }
 
+    const { overrideQueriesByFragment } = otherOptions;
+
     const variables = buildVariablesImpl(introspectionResults)(
       resource,
       aorFetchType,
       params,
-      queryType
+      queryType,
     );
     const query = buildGqlQueryImpl(introspectionResults)(
       resource,
       aorFetchType,
       queryType,
-      variables
+      variables,
+      overrideQueriesByFragment
     );
     const parseResponse = getResponseParserImpl(introspectionResults)(
       aorFetchType,

--- a/src/adaptator/index.js
+++ b/src/adaptator/index.js
@@ -15,7 +15,9 @@ import {
   UPDATE_MANY
 } from 'react-admin';
 
-import buildQuery from './buildQuery';
+import prismaBuildQuery from './buildQuery';
+
+export const buildQuery = prismaBuildQuery;
 
 const defaultOptions = {
   buildQuery,
@@ -35,10 +37,10 @@ const defaultOptions = {
 };
 
 //TODO: Prisma supports batching (UPDATE_MANY, DELETE_MANY)
-export default async options => {
-  const graphQLDataProvider = await buildDataProvider(merge({}, defaultOptions, options));
-
-  return (fetchType, resource, params) => {
-    return graphQLDataProvider(fetchType, resource, params);
-  };
+export default options => {
+  return buildDataProvider(merge({}, defaultOptions, options)).then(graphQLDataProvider => {
+    return (fetchType, resource, params) => {
+      return graphQLDataProvider(fetchType, resource, params);
+    };
+  });
 };

--- a/src/adaptator/index.js
+++ b/src/adaptator/index.js
@@ -35,45 +35,10 @@ const defaultOptions = {
 };
 
 //TODO: Prisma supports batching (UPDATE_MANY, DELETE_MANY)
-export default options => {
-  return buildDataProvider(merge({}, defaultOptions, options)).then(defaultDataProvider => {
-    return (fetchType, resource, params) => {
-      // Graphcool does not support multiple deletions so instead we send multiple DELETE requests
-      // This can be optimized using the apollo-link-batch-http link
-      if (fetchType === DELETE_MANY) {
-        const { ids, ...otherParams } = params;
-        return Promise.all(
-          params.ids.map(id =>
-            defaultDataProvider(DELETE, resource, {
-              id,
-              ...otherParams
-            })
-          )
-        ).then(results => {
-          const data = results.reduce((acc, { data }) => [...acc, data.id], []);
+export default async options => {
+  const graphQLDataProvider = await buildDataProvider(merge({}, defaultOptions, options));
 
-          return { data };
-        });
-      }
-      // Graphcool does not support multiple deletions so instead we send multiple UPDATE requests
-      // This can be optimized using the apollo-link-batch-http link
-      if (fetchType === UPDATE_MANY) {
-        const { ids, ...otherParams } = params;
-        return Promise.all(
-          params.ids.map(id =>
-            defaultDataProvider(UPDATE, resource, {
-              id,
-              ...otherParams
-            })
-          )
-        ).then(results => {
-          const data = results.reduce((acc, { data }) => [...acc, data.id], []);
-
-          return { data };
-        });
-      }
-
-      return defaultDataProvider(fetchType, resource, params);
-    };
-  });
+  return (fetchType, resource, params) => {
+    return graphQLDataProvider(fetchType, resource, params);
+  };
 };

--- a/src/components/attributes/index.js
+++ b/src/components/attributes/index.js
@@ -40,12 +40,8 @@ export const AttributeList = props => (
     <Datagrid>
       <TextField source="id" />
       <TextField source="value" />
-      <ReferenceField source="category.id" reference="Category">
-        <TextField source="name" />
-      </ReferenceField>
-      <ReferenceField source="shop.id" reference="Shop">
-        <TextField source="name" />
-      </ReferenceField>
+      <TextField label="Category" source="category.name" />
+      <TextField label="Shop" source="shop.name" />
       <EditButton />
       <ShowButton />
     </Datagrid>
@@ -72,12 +68,8 @@ export const AttributeShow = props => (
     <SimpleShowLayout>
       <TextField source="id" />
       <TextField source="value" />
-      <ReferenceField source="category.id" reference="Category">
-        <TextField source="name" />
-      </ReferenceField>
-      <ReferenceField source="shop.id" reference="Shop">
-        <TextField source="name" />
-      </ReferenceField>
+      <TextField label="Category" source="category.name" />
+      <TextField label= "Shop" source="shop.name" />
     </SimpleShowLayout>
   </Show>
 );

--- a/src/components/brands/index.js
+++ b/src/components/brands/index.js
@@ -37,12 +37,8 @@ export const BrandList = props => (
     <Datagrid>
       <TextField source="id"/>
       <TextField source="name"/>
-      <ReferenceField source="category.id" reference="Category">
-        <TextField source="name"/>
-      </ReferenceField>
-      <ReferenceField source="shop.id" reference="Shop">
-        <TextField source="name"/>
-      </ReferenceField>
+      <TextField label="Category" source="category.name" />
+      <TextField label="Shop" source="shop.name" />
       <EditButton/>
       <ShowButton/>
     </Datagrid>
@@ -69,12 +65,8 @@ export const BrandShow = props => (
     <SimpleShowLayout>
       <TextField source="id"/>
       <TextField source="name"/>
-      <ReferenceField source="category.id" reference="Category">
-        <TextField source="name"/>
-      </ReferenceField>
-      <ReferenceField source="shop.id" reference="Shop">
-        <TextField source="name"/>
-      </ReferenceField>
+      <TextField label="Category" source="category.name" />
+      <TextField label="Shop" source="shop.name" />
     </SimpleShowLayout>
   </Show>
 );

--- a/src/components/categories/index.js
+++ b/src/components/categories/index.js
@@ -39,9 +39,7 @@ export const CategoryList = props => (
     <Datagrid>
       <TextField source="id" />
       <TextField source="name" />
-      <ReferenceField source="shop.id" reference="Shop">
-        <TextField source="name" />
-      </ReferenceField>
+      <TextField label="Shop" source="shop.name" />
       <EditButton />
       <ShowButton />
     </Datagrid>

--- a/src/components/options/index.js
+++ b/src/components/options/index.js
@@ -21,7 +21,8 @@ import {
   NumberField,
   BooleanField,
   SelectInput,
-  SimpleShowLayout
+  SimpleShowLayout,
+  ArrayField
 } from 'react-admin';
 import React from 'react';
 
@@ -39,14 +40,12 @@ export const OptionList = props => (
     <Datagrid>
       <TextField source="id" />
       <TextField source="name" />
-      <ReferenceManyField label="Values" target="option.id" reference="OptionValue">
+      <ArrayField label="Values" source="values" reference="OptionValue">
         <SingleFieldList>
           <ChipField source="name" />
         </SingleFieldList>
-      </ReferenceManyField>
-      <ReferenceField source="shop.id" reference="Shop">
-        <TextField source="name" />
-      </ReferenceField>
+      </ArrayField>
+      <TextField label="Shop" source="shop.name" />
       <EditButton />
       <ShowButton />
     </Datagrid>

--- a/src/components/orders/index.js
+++ b/src/components/orders/index.js
@@ -15,7 +15,8 @@ import {
   TextInput,
   NumberField,
   FunctionField,
-  BooleanField, Filter, ReferenceInput, SelectInput
+  BooleanField, Filter, ReferenceInput, SelectInput,
+  ArrayField
 } from 'react-admin';
 import React from "react";
 
@@ -30,43 +31,30 @@ export const OrderFilter = props => (
 export const OrderList = props => (
   <List filters={<OrderFilter />} {...props}>
     <Datagrid>
-      <ReferenceField label="Buyer" source="owner.id" reference="User">
-        <TextField source="firstName" />
-      </ReferenceField>
+      <TextField label="Buyer" source="owner.firstName" />
 
-      <ReferenceManyField label="Products" target="order.id" reference="OrderLineItem">
+      <ArrayField label="Products" source="lineItems" reference="OrderLineItem">
         <Datagrid>
 
-          <ReferenceField label="Name" source="variant.id" reference="Variant">
-            <ReferenceField source="product.id" reference="Product">
-              <TextField source="name" />
-            </ReferenceField>
-          </ReferenceField>
+          <TextField label="Product" source="variant.product.name" />
 
-          <ReferenceField label="Price" source="variant.id" reference="Variant">
-            <NumberField
-              source="price"
-              options={{ style: "currency", currency: "EUR" }}
-            />
-          </ReferenceField>
+          <NumberField
+            label="Price"
+            source="variant.price"
+            options={{ style: "currency", currency: "EUR" }}
+          />
 
-          <ReferenceField label="Variants" source="variant.id" reference="Variant">
-            <ReferenceManyField target="variant.id" reference="SelectedOption">
-              <SingleFieldList>
-                <ReferenceField source="value.id" reference="OptionValue">
-                  <ChipField source="name"/>
-                </ReferenceField>
-              </SingleFieldList>
-            </ReferenceManyField>
-          </ReferenceField>
+          <ArrayField label="Values" source="variant.selectedOptions">
+            <SingleFieldList>
+              <ChipField source="value.name"/>
+            </SingleFieldList>
+          </ArrayField>
 
-          <ReferenceField label="Available" source="variant.id" reference="Variant">
-            <BooleanField source="available"/>
-          </ReferenceField>
+          <BooleanField label="Available" source="variant.available"/>
 
-          <TextField source="quantity" />
+          <TextField label="Quantity" source="quantity" />
         </Datagrid>
-      </ReferenceManyField>
+      </ArrayField>
       <NumberField
         source="totalPrice"
         options={{ style: "currency", currency: "EUR" }}

--- a/src/components/products/index.js
+++ b/src/components/products/index.js
@@ -20,7 +20,8 @@ import {
   SelectArrayInput,
   SelectInput,
   ArrayInput,
-  SimpleFormIterator
+  SimpleFormIterator,
+  ArrayField
 } from "react-admin";
 import React from 'react'
 
@@ -47,20 +48,14 @@ export const ProductList = props => (
     <Datagrid>
       <TextField source="id"/>
       <TextField source="name"/>
-      <ReferenceField label="Brand" source="brand.id" reference="Brand">
-        <TextField source="name" />
-      </ReferenceField>
-      <ReferenceManyField label="Attributes" target="products_some.id" reference="Attribute">
+      <TextField label="Brand" source="brand.name" />
+      <ArrayField label="Attributes" source="attributes" reference="Attribute">
         <SingleFieldList>
           <ChipField source="value"/>
         </SingleFieldList>
-      </ReferenceManyField>
-      <ReferenceField label="Category" source="category.id" reference="Category">
-        <TextField source="name" />
-      </ReferenceField>
-      <ReferenceField label="Shop" source="shop.id" reference="Shop">
-        <TextField source="name" />
-      </ReferenceField>
+      </ArrayField>
+      <TextField label="Category" source="category.name" />
+      <TextField label="Shop" source="shop.name" />
       <EditButton/>
       <ShowButton/>
     </Datagrid>

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,0 +1,122 @@
+import { GET_LIST } from 'react-admin';
+import gql from 'graphql-tag';
+
+export default {
+  Product: {
+    [GET_LIST]: gql`
+      fragment product on Product {
+        id
+        name
+        description
+        brand {
+          id
+          name
+        }
+        category {
+          id
+          name
+        }
+        shop {
+          id
+          name
+        }
+        attributes {
+          id
+          value
+        }
+      }
+    `
+  },
+  Order: {
+    [GET_LIST]: gql`
+      fragment order on Order {
+        id
+        totalPrice
+        owner {
+          id
+          firstName
+        }
+        lineItems {
+          id
+          quantity
+          variant {
+            id
+            available
+            price
+            product {
+              id
+              name
+            }
+            selectedOptions {
+              id
+              value {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    `
+  },
+  Brand: {
+    [GET_LIST]: gql`
+      fragment brand on Brand {
+        id
+        name
+        category {
+          id
+          name
+        }
+        shop {
+          id
+          name
+        }
+      }
+    `
+  },
+  Category: {
+    [GET_LIST]: gql`
+      fragment category on Category {
+        id
+        name
+        shop {
+          id
+          name
+        }
+      }
+    `
+  },
+  Attribute: {
+    [GET_LIST]: gql`
+      fragment attribute on Attribute {
+        id
+        value
+        category {
+          id
+          name
+        }
+        shop {
+          id
+          name
+        }
+      }
+    `
+  },
+  Option: {
+    [GET_LIST]: gql`
+      fragment option on Option {
+        id
+        name
+        values {
+          id
+          name
+        }
+        shop {
+          id
+          name
+        }
+      }
+    `
+  }
+};


### PR DESCRIPTION
Used both `gql` and literral strings to show it is possible to use both.
- Pros of using `gql` is that your IDE might provide you syntax highlighting + autocompletion.

I was able to remove **all** `<ReferenceField />` and `<ReferenceManyField />` by simples `<TextField />` and `<ArrayField />`, meaning all `<List />` components now load in a single query. Performances were more than greatly improved.

The only cons right now is that we'll have to manually handle refs to other resources as `react-admin` no longer can automatically generate the `<Link />`.

Here's a codesandbox plugged on that branch:

[![Edit ra-data-prisma](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/Weakky/ra-data-prisma/tree/feature-override-queries/?module=%2Fsrc%2FApp.js)